### PR TITLE
Don't merge - just displaying OpenQ submissions process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ This repository contains an issue tracker that allows sponsors to post bounties 
 ![ETHBrno Banner](https://github.com/ethbrno/.github/blob/main/profile/ethbrno-cover.png)
 
 _Note that in order to win a main track hackathon prize or meta award, you do not have to apply for sponsor bounties. The sponsor bounties are an additional incentive/bounty unrelated to the main hackathon prizes._
+
+Displaying how it works on OpenQ.


### PR DESCRIPTION
closes #1 
Not a real submission, just showing how this works via OpenQ.
Submitters should add a comment for the relevant issue, then the submitted PR will appear in the OpenQ "Submissions" tab for that contract.
For more info check the docs here: https://docs.openq.dev/contest-contracts/submit-your-project